### PR TITLE
Print from and to version for modified dependencies

### DIFF
--- a/src/namenu/deps_diff.clj
+++ b/src/namenu/deps_diff.clj
@@ -34,15 +34,21 @@
   (output/cli data))
 
 (defn diff*
+  "Returns a map of :removed, :added and :modified dependencies.
+  Each key is a dependency name and the value is a map of :from and :to versions"
   [deps-from deps-to]
   (let [key-set (comp set keys)
-
-        [removed-deps added-deps common-deps] (data/diff (key-set deps-from) (key-set deps-to))]
-    ;; don't need to sort here
-    {:removed  (into (sorted-map) (select-keys deps-from removed-deps))
-     :added    (into (sorted-map) (select-keys deps-to added-deps))
-     :modified (into (sorted-map) (set/difference (set (select-keys deps-to common-deps))
-                                                  (select-keys deps-from common-deps)))}))
+        [removed-deps added-deps common-deps] (data/diff (key-set deps-from) (key-set deps-to))
+        removed (map (fn [k] [k {:from (get deps-from k)}]) removed-deps)
+        added (map (fn [k] [k {:to (get deps-to k)}]) added-deps)
+        modified-keys (keys (set/difference (set (select-keys deps-to common-deps))
+                                            (select-keys deps-from common-deps)))
+        modified (map (fn [k] [k {:from (get deps-from k)
+                                  :to   (get deps-to k)}])
+                      modified-keys)]
+    {:removed  (into {} removed)
+     :added    (into {} added)
+     :modified (into {} modified)}))
 
 (defn diff
   "

--- a/src/namenu/deps_diff/output.clj
+++ b/src/namenu/deps_diff/output.clj
@@ -15,8 +15,18 @@
    :added    "https://img.shields.io/badge/Added-green"
    :modified "https://img.shields.io/badge/Modified-blue"})
 
+(defn ver-string
+  "Creates a version string from a map of :from and :to version data.
+
+  Handles the case where only :to or :from is precent (because of adding/removing a dependency)."
+  [{:keys [from to] :as ver}]
+  (cond
+    (and (some? from) (some? to)) (str (make-ver from) " -> " (make-ver to))
+    (some? to) (make-ver to)
+    (some? from) (make-ver from)))
+
 (defn make-row [operation [dep ver]]
-  (str "| ![](" (get assets-url operation) ") | `" dep "` | " (make-ver ver) " |"))
+  (str "| ![](" (get assets-url operation) ") | `" dep "` | " (ver-string ver) " |"))
 
 (defn markdown
   [{:keys [removed added modified]}]
@@ -49,7 +59,7 @@
                  name
                  "  "]
                 [:yellow
-                 (make-ver ver)]))
+                 (ver-string ver)]))
             removed)
 
       (run! (fn [[name ver]]
@@ -63,7 +73,7 @@
                  name
                  "  "]
                 [:yellow
-                 (make-ver ver)]))
+                 (ver-string ver)]))
             added)
 
       (run! (fn [[name ver]]
@@ -77,7 +87,7 @@
                  name
                  "  "]
                 [:yellow
-                 (make-ver ver)]))
+                 (ver-string ver)]))
             modified))))
 
 (comment
@@ -110,4 +120,4 @@
           :pad   :right} "Modified"]
         "  "
         [{:font :yellow}
-         "2.0"])))
+         "1.0 -> 2.0"])))


### PR DESCRIPTION
This PR prints the previous version if the dependency is modified. This can be helpful to better understand how dependencies are changing.

Example:

```
| Operation | Artifact  | Version |
| --------- | --------- | ------- |
| ![](https://img.shields.io/badge/Removed-red) | `hato/hato` | 0.9.0 |
| ![](https://img.shields.io/badge/Added-green) | `prismatic/schema` | 1.2.0 |
| ![](https://img.shields.io/badge/Modified-blue) | `org.clojure/spec.alpha` | 0.2.194 -> 0.3.218 |
| ![](https://img.shields.io/badge/Modified-blue) | `org.clojure/core.specs.alpha` | 0.2.56 -> 0.2.62 |
| ![](https://img.shields.io/badge/Modified-blue) | `org.clojure/clojure` | 1.10.3 -> 1.11.1 |
```

| Operation | Artifact  | Version |
| --------- | --------- | ------- |
| ![](https://img.shields.io/badge/Removed-red) | `hato/hato` | 0.9.0 |
| ![](https://img.shields.io/badge/Added-green) | `prismatic/schema` | 1.2.0 |
| ![](https://img.shields.io/badge/Modified-blue) | `org.clojure/spec.alpha` | 0.2.194 -> 0.3.218 |
| ![](https://img.shields.io/badge/Modified-blue) | `org.clojure/core.specs.alpha` | 0.2.56 -> 0.2.62 |
| ![](https://img.shields.io/badge/Modified-blue) | `org.clojure/clojure` | 1.10.3 -> 1.11.1 |

With the CLI:

<img width="736" alt="Screenshot of Safari (18-10-23, 10-18-01 AM)" src="https://github.com/namenu/deps-diff/assets/811954/a5d3927a-95b5-4c75-bef8-e736fe2f923f">
